### PR TITLE
Convert target-pointer-width from str to u16

### DIFF
--- a/src/x86_64-unknown-none.json
+++ b/src/x86_64-unknown-none.json
@@ -4,7 +4,7 @@
   "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
   "arch": "x86_64",
   "target-endian": "little",
-  "target-pointer-width": "64",
+  "target-pointer-width": 64,
   "target-c-int-width": 32,
   "os": "none",
   "executables": true,


### PR DESCRIPTION
cargo build in Docker container throws an error when it detects a string, causing the compilation to fail. This fixes it in the container, and does not change any behaviours in the nix environment.